### PR TITLE
Various tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ This little experiment introduces two new schemes for (ftl and ftls for **f**ire
 xdg-mime default firefox-ftl.desktop x-scheme-handler/ftl
 xdg-mime default firefox-ftl.desktop x-scheme-handler/ftls
 ```
+
+#### Bypassing the `Open FTL Handler` Prompts
+
+Chrome may display an "Open FTL Handler" prompt, which can only be permanently accepted per-domain.
+
+Potential fix here: https://superuser.com/a/1588146
+
+```bash
+sudo bash
+mkdir -p /etc/opt/chrome/policies/{managed,recommended}
+cat <<EOF >/etc/opt/chrome/policies/managed/allow_tel_protocol.json
+{
+  "URLWhitelist": [
+    "tel:*"
+  ],
+  "URLAllowlist": [
+    "tel:*"
+  ]
+}
+EOF
+```

--- a/background.js
+++ b/background.js
@@ -13,7 +13,11 @@ chrome.runtime.onInstalled.addListener(() => {
         condition: { 
           regexFilter: "^(http)(s?://.*)",
           resourceTypes: ["main_frame"],
-          excludedRequestDomains: ["teams.microsoft.com", "login.microsoftonline.com"],
+          excludedRequestDomains: [
+            "teams.microsoft.com",
+            "login.microsoftonline.com",
+            "outlook.office.com",
+          ],
         },
       },
     ],

--- a/ubuntu/firefox-ftl.desktop
+++ b/ubuntu/firefox-ftl.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=FTL Handler
-Exec=sh -c 'firefox $(echo %u | sed "s/^ftls:/https:/;s/^ftl:/http:/")'
+Exec=sh -c 'firefox "$(echo "%u" | sed "s/^ftls:/https:/;s/^ftl:/http:/")"'
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/ftl;x-scheme-handler/ftls;


### PR DESCRIPTION
A couple of small QOL tweaks:

1. Allow permanently bypassing all `Open FTL Handler` links
2. Add support for the Outlook PWA
3. Support links with spaces (`%20`) in them

Thank you very much for this idea! Constantly copying links from Chrome -> Firefox was driving me crazy.