### PR TITLE
Fix URLWhitelist/URLAllowlist notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ mkdir -p /etc/opt/chrome/policies/{managed,recommended}
 cat <<EOF >/etc/opt/chrome/policies/managed/allow_tel_protocol.json
 {
   "URLWhitelist": [
-    "tel:*"
+    "ftl:*", "ftls:*", 
   ],
   "URLAllowlist": [
-    "tel:*"
+    "ftl:*", "ftls:*", 
   ]
 }
 EOF


### PR DESCRIPTION
We need to whitelist the FTL links, not `tel:`.

Hopefully this means people can fix the issue without needing to visit the superuser.com answer.