### PR TITLE
Add outlook.office365.com to excluded domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,6 +17,7 @@ chrome.runtime.onInstalled.addListener(() => {
             "teams.microsoft.com",
             "login.microsoftonline.com",
             "outlook.office.com",
+            "outlook.office365.com",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- Add `outlook.office365.com` to the list of excluded domains so Outlook links are not redirected to the FTL handler

## Test plan
- [ ] Click an outlook.office365.com link in Teams and verify it opens in Edge, not Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)