### PR TITLE
use hidden iframe instead of window.location.href to prevent page reload

### DIFF
--- a/content.js
+++ b/content.js
@@ -23,5 +23,9 @@ document.addEventListener("click", (e) => {
   e.stopPropagation();
 
   const ftlUrl = url.replace(/^https:/, "ftls:").replace(/^http:/, "ftl:");
-  window.location.href = ftlUrl;
+  const iframe = document.createElement("iframe");
+  iframe.style.display = "none";
+  iframe.src = ftlUrl;
+  document.body.appendChild(iframe);
+  setTimeout(() => document.body.removeChild(iframe), 1000);
 }, true);


### PR DESCRIPTION
Thanks for the great script! Works like a charm.

I encountered an issue when clicking on links inside a Teams call. The call ended immediately.
This is due to window.location.href navigates the Teams tab, ending active calls.
I found a solution using a hidden iFrame, which keeps the call active.