### PR TITLE
Fix command injection in FTL protocol handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To avoid dropping an active Teams call when a link is clicked, the redirect is t
 ## Installation
 
 1. clone this repo `git clone git@github.com:frederic-klein/teams-pwa-link-redirect.git`
+1. install the handler script: `sudo install -m 755 ubuntu/ftl-open /usr/local/bin/ftl-open`
 1. make the firefox-ftl.desktop file available in your system: `sudo cp ubuntu/firefox-ftl.desktop /usr/share/applications/`
 1. install the chrome extension
     1. open chrome

--- a/ubuntu/firefox-ftl.desktop
+++ b/ubuntu/firefox-ftl.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=FTL Handler
-Exec=sh -c 'firefox "$(echo "%u" | sed "s/^ftls:/https:/;s/^ftl:/http:/")"'
+Exec=/usr/local/bin/ftl-open %u
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/ftl;x-scheme-handler/ftls;

--- a/ubuntu/ftl-open
+++ b/ubuntu/ftl-open
@@ -1,0 +1,7 @@
+#!/bin/sh
+u="$1"
+case "$u" in
+  ftls:*) u="https:${u#ftls:}" ;;
+  ftl:*)  u="http:${u#ftl:}" ;;
+esac
+exec firefox "$u"


### PR DESCRIPTION
%u was interpolated into a double-quoted shell string in
firefox-ftl.desktop, so a crafted ftl:/ftls: URL containing $(...)
or backticks would execute arbitrary commands when Chrome invoked
the handler. Replace the inline sed/shell pipeline with a small
script (ubuntu/ftl-open) that receives the URL as $1, so it's never
re-parsed by a shell
