### PR TITLE
Harden ftl-open: reject unsupported URLs, document upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ xdg-mime default firefox-ftl.desktop x-scheme-handler/ftl
 xdg-mime default firefox-ftl.desktop x-scheme-handler/ftls
 ```
 
+## Upgrading from a version before the `ftl-open` handler script
+
+Earlier versions handled the scheme rewrite with an inline shell pipeline in `firefox-ftl.desktop`. That interpolated the clicked URL into a shell command string, so a crafted `ftl:`/`ftls:` URL could execute arbitrary commands as your user ([#14](https://github.com/frederic-klein/teams-pwa-link-redirect/pull/14)). Any page you visited could trigger it.
+
+If you installed before that fix, an already-copied `.desktop` file in `/usr/share/applications/` is still the vulnerable one — pulling the repo alone changes nothing. Install the script and overwrite the old handler:
+
+```BASH
+sudo install -m 755 ubuntu/ftl-open /usr/local/bin/ftl-open
+sudo cp ubuntu/firefox-ftl.desktop /usr/share/applications/
+```
+
+The two files must always be updated together; the `.desktop` file does nothing without the script.
+
 ### Bypassing the `Open FTL Handler` Prompts
 
 Chrome may display an "Open FTL Handler" prompt, which can only be permanently accepted per-domain.

--- a/ubuntu/ftl-open
+++ b/ubuntu/ftl-open
@@ -3,5 +3,6 @@ u="$1"
 case "$u" in
   ftls:*) u="https:${u#ftls:}" ;;
   ftl:*)  u="http:${u#ftl:}" ;;
+  *) echo "ftl-open: unsupported URL" >&2; exit 1 ;;
 esac
 exec firefox "$u"


### PR DESCRIPTION
Follow-up to #14. Two remaining items from a security review of that PR.

## 1. `ftl-open` rejects unsupported input

The `case` in `ubuntu/ftl-open` had no default branch, so anything that wasn't `ftl:`/`ftls:` was passed to Firefox verbatim. Since the script installs into `/usr/local/bin`, it sits on every local process's `PATH`, which made it a general-purpose "open anything in Firefox with arbitrary CLI arguments" gadget — including `-`-prefixed strings, which Firefox parses as options (`-P`, `-chrome`, `--screenshot`) rather than URLs.

Adding the reject branch also guarantees the argument handed to Firefox always begins with `http:`/`https:` and can therefore never look like a flag.

This is defence in depth, not a live hole: the scheme handler itself only ever feeds the script `ftl:`/`ftls:` URLs. It closes the surface for any *other* caller.

Verified against the changed script (with `firefox` stubbed):

| input | result |
|---|---|
| `ftls://example.com/a?b=c&d=e` | `https://example.com/a?b=c&d=e` |
| `ftl://example.com/p` | `http://example.com/p` |
| `ftls://x/$(id)` | passed through inert, no expansion |
| `http://already-http/` | rejected, exit 1 |
| `-P` | rejected, exit 1 |
| `ftlsomething:x` | rejected, exit 1 |
| *(no argument)* | rejected, exit 1 |

## 2. Upgrade note in the README

#14 added the install step for new users, but anyone who installed earlier still has the vulnerable `.desktop` file sitting in `/usr/share/applications/` — pulling the repo doesn't change that, and nothing told them to re-copy it. Adds an explicit upgrade section covering both files, and notes that the two must always be updated together since the `.desktop` file is inert without the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
